### PR TITLE
Add a sample UserProfile project and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module uses a REDCap project to manage and store additional user attributes
 If you are working in a test instance, you must turn on some form of authentication as this module builds upon account management features. Table-based authentication will work fine.
 
 ### Create an User Profile project
-Create a REDCap project in order to extend user information according to your needs - e.g. address, country of birth, job position, etc. **Make sure to create a field that represents REDCap username** - that's how user accounts and profiles are connected.
+Create a REDCap project in order to extend user information according to your needs - e.g. address, country of birth, job position, etc. **Make sure to create a field that represents REDCap username** - that's how user accounts and profiles are connected.  A sample user profile project is available in [samples folder](samples/UserProfile.xml)
 
 ### Filling the settings form
 Go to **Control Center > Manage External Modules**, click on User Profile's **Configure** button, and fill the form as follows:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # REDCap User Profile
 REDCap User Profile is an external module that extends user accounts information according to your needs - e.g. address, country of birth, job position, etc. This module provides:
+
 - An easy way to manage user profiles
 - An API to assist developers in accessing user profiles information
 
@@ -7,10 +8,10 @@ REDCap User Profile is an external module that extends user accounts information
 This module uses a REDCap project to manage and store additional user attributes as data entry records.
 
 ## Prerequisites
-- [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules)
+- REDCap >= 8.0.0 (for versions < 8.0.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
 
 ## Installation
-- Clone this repo into to `<redcap-root>/modules/redcap_user_profile_v1.0`.
+- Clone this repo into to `<redcap-root>/modules/redcap_user_profile_v<module-version-number>`.
 - Go to **Control Center > Manage External Modules** and enable User Profile for all modules.
 
 ## Configuration
@@ -23,6 +24,7 @@ Create a REDCap project in order to extend user information according to your ne
 
 ### Filling the settings form
 Go to **Control Center > Manage External Modules**, click on User Profile's **Configure** button, and fill the form as follows:
+
   - **Project**: The project you created
   - **Username field**: The key of username field you created
 
@@ -33,7 +35,7 @@ You can manage user profiles in two ways.
 Directly on User Profile project - creating new records, making sure to associate a REDCap username for each profile.
 
 ### Option 2
-By accessing user account page (go to **Control Manager > Browse Users** and click on **View Users** to choose the account). 
+By accessing user account page (go to **Control Manager > Browse Users** and click on **View Users** to choose the account).
 
 There, you will be able to see a **Create User Profile** button or an **Edit User Profile** button. Either button will redirect you to the user profile form - for new profiles, the username field will be automatically prefilled.
 
@@ -53,6 +55,7 @@ $address = $data['street_address'];
 ```
 
 Here are other methods that might be useful:
+
 ```php
 <?php
 
@@ -70,6 +73,7 @@ $profile->getProjectId();
 ```
 
 There is also a static method to get all available profiles.
+
 ```php
 <?php
 

--- a/samples/UserProfile.xml
+++ b/samples/UserProfile.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="User Profile" AsOfDateTime="2017-11-28T08:47:35" CreationDateTime="2017-11-28T08:47:35" SourceSystem="REDCap" SourceSystemVersion="7.6.9">
+<Study OID="Project.UserProfile">
+<GlobalVariables>
+	<StudyName>User Profile</StudyName>
+	<StudyDescription>This file contains the metadata, events, and data for REDCap project "User Profile".</StudyDescription>
+	<ProtocolName>User Profile</ProtocolName>
+	<redcap:RecordAutonumberingEnabled>1</redcap:RecordAutonumberingEnabled>
+	<redcap:CustomRecordLabel>[send_rx_user_first_name] [send_rx_user_last_name]</redcap:CustomRecordLabel>
+	<redcap:SecondaryUniqueField></redcap:SecondaryUniqueField>
+	<redcap:SchedulingEnabled>0</redcap:SchedulingEnabled>
+	<redcap:Purpose>0</redcap:Purpose>
+	<redcap:PurposeOther></redcap:PurposeOther>
+	<redcap:ProjectNotes></redcap:ProjectNotes>
+</GlobalVariables>
+<MetaDataVersion OID="Metadata.UserProfile_2017-11-28_0847" Name="User Profile" redcap:RecordIdField="profile_id">
+	<FormDef OID="Form.profile_info" Name="Profile Info" Repeating="No" redcap:FormName="profile_info">
+		<ItemGroupRef ItemGroupOID="profile_info.profile_id" Mandatory="No"/>
+		<ItemGroupRef ItemGroupOID="profile_info.profile_info_complete" Mandatory="No"/>
+	</FormDef>
+	<ItemGroupDef OID="profile_info.profile_id" Name="Profile Info" Repeating="No">
+		<ItemRef ItemOID="profile_id" Mandatory="No" redcap:Variable="profile_id"/>
+		<ItemRef ItemOID="user_id" Mandatory="Yes" redcap:Variable="user_id"/>
+		<ItemRef ItemOID="user_phone" Mandatory="Yes" redcap:Variable="user_phone"/>
+		<ItemRef ItemOID="user_address" Mandatory="Yes" redcap:Variable="user_address"/>
+		<ItemRef ItemOID="user_name_on_prescription" Mandatory="No" redcap:Variable="user_name_on_prescription"/>
+		<ItemRef ItemOID="user_dea" Mandatory="No" redcap:Variable="user_dea"/>
+		<ItemRef ItemOID="user_license" Mandatory="No" redcap:Variable="user_license"/>
+	</ItemGroupDef>
+	<ItemGroupDef OID="profile_info.profile_info_complete" Name="Form Status" Repeating="No">
+		<ItemRef ItemOID="profile_info_complete" Mandatory="No" redcap:Variable="profile_info_complete"/>
+	</ItemGroupDef>
+	<ItemDef OID="profile_id" Name="profile_id" DataType="text" Length="999" redcap:Variable="profile_id" redcap:FieldType="text">
+		<Question><TranslatedText>Profile ID</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_id" Name="user_id" DataType="text" Length="999" redcap:Variable="user_id" redcap:FieldType="text" redcap:RequiredField="y">
+		<Question><TranslatedText>REDCap Username</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_phone" Name="user_phone" DataType="text" Length="999" redcap:Variable="user_phone" redcap:FieldType="text" redcap:TextValidationType="phone" redcap:RequiredField="y">
+		<Question><TranslatedText>Phone</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_address" Name="user_address" DataType="text" Length="999" redcap:Variable="user_address" redcap:FieldType="textarea" redcap:RequiredField="y">
+		<Question><TranslatedText>Address</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_name_on_prescription" Name="user_name_on_prescription" DataType="text" Length="999" redcap:Variable="user_name_on_prescription" redcap:FieldType="text" redcap:FieldNote="e.g. Joe Doe, MD.">
+		<Question><TranslatedText>Name on Prescription</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_dea" Name="user_dea" DataType="text" Length="999" redcap:Variable="user_dea" redcap:FieldType="text">
+		<Question><TranslatedText>DEA Number</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="user_license" Name="user_license" DataType="text" Length="999" redcap:Variable="user_license" redcap:FieldType="text">
+		<Question><TranslatedText>Medical License Number</TranslatedText></Question>
+	</ItemDef>
+	<ItemDef OID="profile_info_complete" Name="profile_info_complete" DataType="text" Length="1" redcap:Variable="profile_info_complete" redcap:FieldType="select" redcap:SectionHeader="Form Status">
+		<Question><TranslatedText>Complete?</TranslatedText></Question>
+		<CodeListRef CodeListOID="profile_info_complete.choices"/>
+	</ItemDef>
+	<CodeList OID="profile_info_complete.choices" Name="profile_info_complete" DataType="text" redcap:Variable="profile_info_complete">
+		<CodeListItem CodedValue="0"><Decode><TranslatedText>Incomplete</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="1"><Decode><TranslatedText>Unverified</TranslatedText></Decode></CodeListItem>
+		<CodeListItem CodedValue="2"><Decode><TranslatedText>Complete</TranslatedText></Decode></CodeListItem>
+	</CodeList>
+</MetaDataVersion>
+</Study>
+</ODM>

--- a/samples/UserProfile.xml
+++ b/samples/UserProfile.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="User Profile" AsOfDateTime="2017-11-28T08:47:35" CreationDateTime="2017-11-28T08:47:35" SourceSystem="REDCap" SourceSystemVersion="7.6.9">
+<ODM xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:redcap="https://projectredcap.org" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 schema/odm/ODM1-3-1.xsd" ODMVersion="1.3.1" FileOID="000-00-0000" FileType="Snapshot" Description="User Profile" AsOfDateTime="2017-11-28T15:42:56" CreationDateTime="2017-11-28T15:42:56" SourceSystem="REDCap" SourceSystemVersion="7.6.9">
 <Study OID="Project.UserProfile">
 <GlobalVariables>
 	<StudyName>User Profile</StudyName>
 	<StudyDescription>This file contains the metadata, events, and data for REDCap project "User Profile".</StudyDescription>
 	<ProtocolName>User Profile</ProtocolName>
 	<redcap:RecordAutonumberingEnabled>1</redcap:RecordAutonumberingEnabled>
-	<redcap:CustomRecordLabel>[send_rx_user_first_name] [send_rx_user_last_name]</redcap:CustomRecordLabel>
+	<redcap:CustomRecordLabel>[user_id]</redcap:CustomRecordLabel>
 	<redcap:SecondaryUniqueField></redcap:SecondaryUniqueField>
 	<redcap:SchedulingEnabled>0</redcap:SchedulingEnabled>
 	<redcap:Purpose>0</redcap:Purpose>
 	<redcap:PurposeOther></redcap:PurposeOther>
 	<redcap:ProjectNotes></redcap:ProjectNotes>
 </GlobalVariables>
-<MetaDataVersion OID="Metadata.UserProfile_2017-11-28_0847" Name="User Profile" redcap:RecordIdField="profile_id">
+<MetaDataVersion OID="Metadata.UserProfile_2017-11-28_1542" Name="User Profile" redcap:RecordIdField="profile_id">
 	<FormDef OID="Form.profile_info" Name="Profile Info" Repeating="No" redcap:FormName="profile_info">
 		<ItemGroupRef ItemGroupOID="profile_info.profile_id" Mandatory="No"/>
 		<ItemGroupRef ItemGroupOID="profile_info.profile_info_complete" Mandatory="No"/>


### PR DESCRIPTION
This pull requests adds a sample User Profile project in the form of an CDISC.XML export from REDCap. This project is suitable for use as a template for create a User Project project to work with this module. The README includes a reference to this sample project and numerous small updates. 

Verification steps:

- [x] Use the file samples/UserProfile.xml to create a REDCap project
- [x] Follow the instructions in README.md to configure the the user profile module to use the new project and the user_id filed within in it.
- [x] Access Control Panel -> Browse Users -> View Users to get a list of users.  Select a user and click "Create user profile" to create a user profile. 
- [x] At the new record page, verify the Profile ID is numeric.
- [x] Still at the new record page, verify the user_id field has been pre-filled with this users REDCap username. Fill in any required fields and save the record.
- [x] Return to the user list in Control Panel, access the same user and click "Edit user profile" to access the newly created record. 
- [x] Return to the user list in Control Panel, access a new user and click "Edit user profile" to access the newly created record. 
- [x] Verify that the new record has a numeric profile ID.
- [x] Verify the user_id field has been pre-filled with this users REDCap username. 