### PR TITLE
Updating README, config.json, and fixing regression on config.js

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -38,12 +38,10 @@ class ExternalModule extends AbstractExternalModule {
         // Initializing User Profile JS settings variable.
         echo '<script>var userProfile = {};</script>';
 
-        if (
-            strpos(PAGE, 'ExternalModules/manager/control_center.php') !== false ||
-            strpos(PAGE, 'external_modules/manager/control_center.php') !== false
-        ) {
+        if (strpos(PAGE, 'ExternalModules/manager/control_center.php') !== false) {
             $this->includeJs('js/config.js');
             $this->includeCss('css/config.css');
+            $this->setJsSetting('modulePrefix', $this->PREFIX);
 
             return;
         }

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ REDCap User Profile is an external module that extends user accounts information
 This module uses a REDCap project to manage and store additional user attributes as data entry records.
 
 ## Prerequisites
-- [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules)
+- REDCap >= 8.0.3
 
 ## Installation
-- Clone this repo into to `<redcap-root>/modules/redcap_user_profile_v1.0`.
-- Go to **Control Center > Manage External Modules** and enable User Profile for all modules.
+- Clone this repo into to `<redcap-root>/modules/redcap_user_profile_v<version_number>`.
+- Go to **Control Center > External Modules** and enable User Profile for all modules.
 
 ## Configuration
 
@@ -22,7 +22,7 @@ If you are working in a test instance, you must turn on some form of authenticat
 Create a REDCap project in order to extend user information according to your needs - e.g. address, country of birth, job position, etc. **Make sure to create a field that represents REDCap username** - that's how user accounts and profiles are connected.
 
 ### Filling the settings form
-Go to **Control Center > Manage External Modules**, click on User Profile's **Configure** button, and fill the form as follows:
+Go to **Control Center > External Modules**, click on User Profile's **Configure** button, and fill the form as follows:
   - **Project**: The project you created
   - **Username field**: The key of username field you created
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module uses a REDCap project to manage and store additional user attributes
 
 ## Installation
 - Clone this repo into to `<redcap-root>/modules/redcap_user_profile_v<version_number>`.
-- Go to **Control Center > External Modules** and enable User Profile - it will be enabled for all modules by default.
+- Go to **Control Center > External Modules** and enable User Profile - it will be enabled for all projects by default.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module uses a REDCap project to manage and store additional user attributes
 ### Making sure authentication is enabled
 If you are working in a test instance, you must turn on some form of authentication as this module builds upon account management features. Table-based authentication will work fine.
 
-### Create an User Profile project
+### Create a User Profile project
 Create a REDCap project in order to extend user information according to your needs - e.g. address, country of birth, job position, etc. **Make sure to create a field that represents REDCap username** - that's how user accounts and profiles are connected.  A sample user profile project is available in [samples folder](samples/UserProfile.xml)
 
 ### Filling the settings form

--- a/config.json
+++ b/config.json
@@ -46,5 +46,9 @@
             "required": true,
             "type": "text"
         }
-    ]
+    ],
+    "enable-every-page-hooks-on-system-pages": true,
+    "compatibility": {
+        "redcap-version-min": "8.0.3"
+    }
 }

--- a/js/config.js
+++ b/js/config.js
@@ -1,19 +1,13 @@
 $(document).ready(function() {
-    var $modal = $('#external-modules-configure-modal');
+    ExternalModules.Settings.prototype.configureSettingsOld = ExternalModules.Settings.prototype.configureSettings;
+    ExternalModules.Settings.prototype.configureSettings = function() {
+        ExternalModules.Settings.prototype.configureSettingsOld();
 
-    // We need to force "Enable on all projects by default" on config form.
-    $modal.on('shown.bs.modal', function(e) {
-        // Replacing checkbox with a hidden field.
-        $('.redcap-user-profile [field="enabled"]').replaceWith('<input type="hidden" name="enabled" value="1">');
-        $(this).removeClass('redcap-user-profile');
-    });
-
-    // Hiding checkbox during modal init.
-    // If we only execute the "shown" trigger above, the checkbox will be
-    // weirdly visible for a few moments before it disapears.
-    $modal.on('show.bs.modal', function(e) {
-        if ($(this).data('module') === 'redcap_user_profile') {
-            $(this).addClass('redcap-user-profile');
+        var $modal = $('#external-modules-configure-modal');
+        if ($modal.data('module') !== userProfile.modulePrefix) {
+            return;
         }
-    });
+
+        $modal.find('[field="enabled"]').replaceWith('<input type="hidden" name="enabled" value="1">');
+    }
 });


### PR DESCRIPTION
This PR catches up the newest updates on External Modules. It includes a fix to a regression on the feature of setting the module to be enabled on all projects by default.

Review steps:
- [x] Check changes on `README.md`, `config.json`
- [x] Go to Control Center > External modules, open your User Profile config modal, and make sure you do not see the "Enable module on all projects by default"
- [x] Save form and make sure User Profile is enabled for all projects