### PR TITLE
Forcing module to be enabled for all projects on the backend

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -13,6 +13,7 @@ use ExternalModules\ExternalModules;
 use UserProfile\UserProfile;
 use Project;
 use UserRights;
+use RCView;
 
 /**
  * ExternalModule class for User Profile module.
@@ -39,10 +40,20 @@ class ExternalModule extends AbstractExternalModule {
         echo '<script>var userProfile = {};</script>';
 
         if (strpos(PAGE, 'ExternalModules/manager/control_center.php') !== false) {
+            // Making sure the module is enabled for all projects.
+            // TODO: move it to redcap_module_system_enable as soon as this hook
+            // is released on REDCap.
+            $this->setSystemSetting(ExternalModules::KEY_ENABLED, true);
+
+            // Adding script and style.
             $this->includeJs('js/config.js');
             $this->includeCss('css/config.css');
             $this->setJsSetting('modulePrefix', $this->PREFIX);
 
+            return;
+        }
+
+        if (!$this->projectId) {
             return;
         }
 
@@ -85,15 +96,16 @@ class ExternalModule extends AbstractExternalModule {
         );
 
         foreach ($buttons as $key => $btn_info) {
-            $settings[$key] = '
-                <button type="button" style="padding:1px 5px 2px 5px;" id="user-profile-btn">
-                    <img src="' . APP_PATH_IMAGES . $btn_info['icon'] . '.png" style="vertical-align:middle;">
-                    <span style="vertical-align:middle;">' . $btn_info['label'] . '</span>
-                </button>';
+            $button = RCView::img(array('src' => APP_PATH_IMAGES . $btn_info['icon'] . '.png'));
+            $button .= RCView::span(array(), $btn_info['label']);
+            $button = RCView::button(array('id' => 'user-profile-btn', 'type' => 'button'), $button);
+
+            $settings[$key] = $button;
         }
 
         $this->setJsSetting('addEditButtons', $settings);
         $this->includeJs('js/add_edit_buttons.js');
+        $this->includeCss('css/add_edit_buttons.css');
     }
 
     /**

--- a/add_edit_buttons.css
+++ b/add_edit_buttons.css
@@ -1,0 +1,8 @@
+#user-profile-btn {
+    padding: 1px 5px 2px 5px;
+}
+
+#user-profile-btn img,
+#user-profile-btn span {
+    vertical-align: middle;
+}

--- a/config.json
+++ b/config.json
@@ -10,27 +10,27 @@
         {
             "name": "Philip Chase",
             "email": "pbc@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Taryn Stoffs",
             "email": "tls@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Prasad Lanka",
             "email": "planka@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Dileep Rajput",
             "email": "rajputd@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         },
         {
             "name": "Tiago Bember",
             "email": "tbembersimeao@ufl.edu",
-            "institution": "CTS-IT - University of Florida"
+            "institution": "University of Florida - CTSI"
         }
     ],
     "system-settings": [

--- a/js/config.js
+++ b/js/config.js
@@ -1,13 +1,22 @@
 $(document).ready(function() {
-    ExternalModules.Settings.prototype.configureSettingsOld = ExternalModules.Settings.prototype.configureSettings;
-    ExternalModules.Settings.prototype.configureSettings = function() {
-        ExternalModules.Settings.prototype.configureSettingsOld();
-
-        var $modal = $('#external-modules-configure-modal');
+    $modal = $('#external-modules-configure-modal');
+    $modal.on('show.bs.modal', function() {
+        // Making sure we are overriding this modules's modal only.
         if ($modal.data('module') !== userProfile.modulePrefix) {
             return;
         }
 
-        $modal.find('[field="enabled"]').replaceWith('<input type="hidden" name="enabled" value="1">');
-    }
+        if (typeof ExternalModules.Settings.prototype.configureSettingsOld === 'undefined') {
+            ExternalModules.Settings.prototype.configureSettingsOld = ExternalModules.Settings.prototype.configureSettings;
+        }
+
+        ExternalModules.Settings.prototype.configureSettings = function() {
+            ExternalModules.Settings.prototype.configureSettingsOld();
+
+            // Making sure we are overriding this modules's modal only.
+            if ($modal.data('module') === userProfile.modulePrefix) {
+                $modal.find('tr[field="enabled"] input').attr('disabled', 'disabled').attr('title', 'This module needs to be enabled for all projects.');
+            }
+        };
+    });
 });


### PR DESCRIPTION
* Forcing module to be enabled for all projects on the backend
* Preventing conflicts with other configuration modals
* Refactoring buttons markup construction

Review steps:
- [x] If you have an existing User Profile module, make sure it is disabled
- [x] Enable the module on Control Center
- [x] Make sure you see "Enabled for All Projects" flag
- [x] Open config form and make sure you are not able to change the flag value
- [x] Submit configuration form (create a user profile project if needed - see Configuration section of module documentation if any questions come up)
- [x] Go to users list page, click on any user and make sure there are no regressions on "Add new profile" or "Edit profile" buttons